### PR TITLE
Hoist header component in _app.tsx to retain state

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
 import { faDiscord, faGithub } from "@fortawesome/free-brands-svg-icons";
 import Modal from "./Modal";
 
-export default function Header(props: { currentPage: string }) {
+export default function Header() {
+  const { pathname } = useRouter();
+
   const [imgVis, setImgVis] = useState("");
   const [imgSrc, setImgSrc] = useState("solid-gradient-blue-gray-bunny");
 
@@ -286,7 +289,7 @@ export default function Header(props: { currentPage: string }) {
           <Link
             href="/"
             className={`${
-              props.currentPage == "home"
+              pathname == "/"
                 ? "text-gray-100 bg-sky-600"
                 : "hover:bg-gray-200 active:bg-gray-300"
             } text rounded-md px-2 py-1 transition mr-1.5`}
@@ -296,7 +299,7 @@ export default function Header(props: { currentPage: string }) {
           <Link
             href="/projects"
             className={`${
-              props.currentPage == "projects"
+              pathname.startsWith("/projects")
                 ? "text-gray-100 bg-sky-600"
                 : "hover:bg-gray-200 active:bg-gray-300"
             } text rounded-md px-2 py-1 transition mr-1.5`}
@@ -306,7 +309,7 @@ export default function Header(props: { currentPage: string }) {
           <Link
             href="/blog"
             className={`${
-              props.currentPage == "posts"
+              pathname.startsWith("/blog")
                 ? "text-gray-100 bg-sky-600"
                 : "hover:bg-gray-200 active:bg-gray-300"
             } text rounded-md px-2 py-1 transition mr-1.5`}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,10 +6,11 @@ import { config } from "@fortawesome/fontawesome-svg-core";
 import "@fortawesome/fontawesome-svg-core/styles.css";
 config.autoAddCss = false;
 import { Analytics } from "@vercel/analytics/react";
+import Header from "../components/Header";
 
 const lexend = Lexend({ subsets: ["latin"] });
 
-export default function App({ Component, pageProps }: AppProps) {
+export default function App({ Component, pageProps, router }: AppProps) {
   useEffect(() => {
     console.log(
       "%cOMG HISIES!!!!!!!!!!!!!! 🐰🐰🐰🐰🐰",
@@ -19,6 +20,7 @@ export default function App({ Component, pageProps }: AppProps) {
 
   return (
     <main className={lexend.className}>
+      {router.pathname != "/404" ? <Header /> : null}
       <Component {...pageProps} />
       <Analytics />
     </main>

--- a/src/pages/blog/ap-world-history-a-history.tsx
+++ b/src/pages/blog/ap-world-history-a-history.tsx
@@ -1,4 +1,3 @@
-import Header from "../../components/Header";
 import CommonHead from "../../components/CommonHead";
 import Image from "next/image";
 import Link from "next/link";
@@ -32,9 +31,6 @@ export default function Blog1() {
         />
         <meta property="twitter:card" content="summary_large_image" />
       </CommonHead>
-
-      {/* header */}
-      <Header currentPage="posts" />
 
       {/* post */}
       <h1 className="sub1title pb-0">AP World History: A History</h1>

--- a/src/pages/blog/dialing-letters-instead-of-digits.tsx
+++ b/src/pages/blog/dialing-letters-instead-of-digits.tsx
@@ -1,5 +1,4 @@
 import CommonHead from "../../components/CommonHead";
-import Header from "../../components/Header";
 import CodeBlock from "../../components/CodeBlock";
 import Image from "next/image";
 import Link from "next/link";
@@ -32,9 +31,6 @@ export default function Blog4() {
         />
         <meta property="twitter:card" content="summary_large_image" />
       </CommonHead>
-
-      {/* header */}
-      <Header currentPage="posts" />
 
       {/* post */}
       <h1 className="sub1title pb-0">Dialing Letters Instead of Digits</h1>

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,5 +1,4 @@
 import CommonHead from "../../components/CommonHead";
-import Header from "../../components/Header";
 import Post from "../../components/Post";
 
 export default function Blog() {
@@ -16,9 +15,6 @@ export default function Blog() {
           content="https://bunnies.jakeo.dev/images/solid-gradient-blue-gray-bunny.png"
         />
       </CommonHead>
-
-      {/* header */}
-      <Header currentPage="posts" />
 
       {/* posts */}
       <h2 className="sub1title mt-0">My posts</h2>

--- a/src/pages/blog/p-of-congratulations-we-are-pleased-to-inform-you.tsx
+++ b/src/pages/blog/p-of-congratulations-we-are-pleased-to-inform-you.tsx
@@ -1,5 +1,4 @@
 import CommonHead from "../../components/CommonHead";
-import Header from "../../components/Header";
 import Image from "next/image";
 import Link from "next/link";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -36,9 +35,6 @@ export default function Blog3() {
         />
         <meta property="twitter:card" content="summary_large_image" />
       </CommonHead>
-
-      {/* header */}
-      <Header currentPage="posts" />
 
       {/* post */}
       <h1 className="sub1title pb-0">

--- a/src/pages/blog/the-jakeo-dev-portfolio-wrapped-2023.tsx
+++ b/src/pages/blog/the-jakeo-dev-portfolio-wrapped-2023.tsx
@@ -1,5 +1,4 @@
 import CommonHead from "../../components/CommonHead";
-import Header from "../../components/Header";
 import Image from "next/image";
 import Link from "next/link";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -34,9 +33,6 @@ export default function Blog2() {
         />
         <meta property="twitter:card" content="summary_large_image" />
       </CommonHead>
-
-      {/* header */}
-      <Header currentPage="posts" />
 
       {/* post */}
       <h1 className="sub1title pb-0">The JakeO.dev Portfolio Wrapped 2023</h1>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,4 @@
 import CommonHead from "../components/CommonHead";
-import Header from "../components/Header";
 import Project from "../components/Project";
 import Post from "@/components/Post";
 
@@ -20,9 +19,6 @@ export default function Home() {
           content="https://bunnies.jakeo.dev/images/solid-gradient-blue-gray-bunny.png"
         />
       </CommonHead>
-
-      {/* header */}
-      <Header currentPage="home" />
 
       {/* about me */}
       <h2 className="sub1title mt-0">Welcome to my website!</h2>

--- a/src/pages/projects/cifra.tsx
+++ b/src/pages/projects/cifra.tsx
@@ -1,5 +1,4 @@
 import CommonHead from "../../components/CommonHead";
-import Header from "../../components/Header";
 import Button from "../../components/Button";
 import SecButton from "../../components/SecButton";
 import ImageCarousel from "@/components/ImageCarousel";
@@ -28,9 +27,6 @@ export default function Projects() {
           content="https://bunnies.jakeo.dev/images/solid-gradient-blue-gray-bunny.png"
         />
       </CommonHead>
-
-      {/* header */}
-      <Header currentPage="projects" />
 
       <div className="sub1title flex items-center pb-0">
         <img

--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -1,5 +1,4 @@
 import CommonHead from "../../components/CommonHead";
-import Header from "../../components/Header";
 import Project from "../../components/Project";
 
 export default function Projects() {
@@ -16,9 +15,6 @@ export default function Projects() {
           content="https://bunnies.jakeo.dev/images/solid-gradient-blue-gray-bunny.png"
         />
       </CommonHead>
-
-      {/* header */}
-      <Header currentPage="projects" />
 
       {/* current projects */}
       <h2 className="sub1title mt-0">My projects</h2>

--- a/src/pages/projects/jakeo.tsx
+++ b/src/pages/projects/jakeo.tsx
@@ -1,5 +1,4 @@
 import CommonHead from "../../components/CommonHead";
-import Header from "../../components/Header";
 import SecButton from "../../components/SecButton";
 import Image from "next/image";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -26,9 +25,6 @@ export default function Projects() {
           content="https://bunnies.jakeo.dev/images/solid-gradient-blue-gray-bunny.png"
         />
       </CommonHead>
-
-      {/* header */}
-      <Header currentPage="projects" />
 
       <div className="sub1title flex items-center pb-0">
         <img

--- a/src/pages/projects/linked.tsx
+++ b/src/pages/projects/linked.tsx
@@ -1,5 +1,4 @@
 import CommonHead from "../../components/CommonHead";
-import Header from "../../components/Header";
 import Button from "../../components/Button";
 import SecButton from "../../components/SecButton";
 import Image from "next/image";
@@ -27,9 +26,6 @@ export default function Projects() {
           content="https://bunnies.jakeo.dev/images/solid-gradient-blue-gray-bunny.png"
         />
       </CommonHead>
-
-      {/* header */}
-      <Header currentPage="projects" />
 
       <div className="sub1title flex items-center pb-0">
         <img

--- a/src/pages/projects/plannter.tsx
+++ b/src/pages/projects/plannter.tsx
@@ -1,5 +1,4 @@
 import CommonHead from "../../components/CommonHead";
-import Header from "../../components/Header";
 import Button from "../../components/Button";
 import SecButton from "../../components/SecButton";
 import ImageCarousel from "@/components/ImageCarousel";
@@ -27,9 +26,6 @@ export default function Projects() {
           content="https://bunnies.jakeo.dev/images/solid-gradient-blue-gray-bunny.png"
         />
       </CommonHead>
-
-      {/* header */}
-      <Header currentPage="projects" />
 
       <div className="sub1title flex items-center pb-0">
         <img


### PR DESCRIPTION
# Why
The `<Header />` component is a highly dynamic component that contains a lot of state logic. However, when navigating across pages, the website currently resets the state. This is most evident when you click the bunny, which changes it to something else, but then navigate to another page, upon which the bunny is reset to the original image.

By moving the Header component to `_app.tsx`, the component is not re-rendered from scratch during a page navigation, preserving the state of the component.

This PR also avoids the use of passing a `currentRoute` prop in favor of using the `pathname` property directly from the `useRouter` hook to reduce complexity as well as to prevent state from resetting.

See https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts#examples for more information.